### PR TITLE
[Enhancement]: Updated the react-native-maps package version which is not working with our current React Native version 0.72

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "prepare": "husky install",
+    "postinstall": "cd ios && pod install; cd ..", 
     "android": "react-native run-android",
     "ios": "react-native run-ios",
     "lint": "./node_modules/.bin/eslint --fix",
@@ -33,7 +34,7 @@
     "react-native-gesture-handler": "^2.13.4",
     "react-native-image-crop-picker": "^0.40.0",
     "react-native-linear-gradient": "^2.8.3",
-    "react-native-maps": "^1.7.1",
+    "react-native-maps": "1.7.1",
     "react-native-media-controls": "^2.3.0",
     "react-native-mentions": "^1.1.4",
     "react-native-parsed-text": "^0.0.22",


### PR DESCRIPTION

What does this PR do?
This PR updates the react-native-maps package to version 1.7.1, which resolves compatibility issues with the current React Native version 0.72. The issue was causing the build to fail on both iOS and Android platforms.

Related Issue:
#8

Changes Made:

Updated package.json:
Added "react-native-maps": "1.7.1" to the dependencies.
Removed the node_modules and yarn.lock.
Reinstalled Dependencies: run yarn to reinstall all dependencies.
iOS Setup:
Executed pod install in the ios directory.
Android and iOS Build:
run yarn android and yarn ios to build and verify that the app works correctly on both platforms.



How to Test:

Steps to test:
Pull the latest changes from this PR.
Run yarn to install the updated dependencies.
For iOS, navigate to the ios directory and run pod install.
Run yarn android to build and test on Android.
Run yarn ios to build and test on iOS.
Verify that the app builds successfully and the maps feature works as expected on both platforms.



Additional Notes:

The issue was resolved by downgrading the react-native-maps package to version 1.7.1, which is compatible with React Native 0.72.



